### PR TITLE
Add type checker

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,7 @@ dependencies:
 - base >= 4.7 && < 5
 - array
 - containers
+- mtl
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,7 @@ build-tools:
 dependencies:
 - base >= 4.7 && < 5
 - array
+- containers
 
 library:
   source-dirs: src

--- a/signe.cabal
+++ b/signe.cabal
@@ -26,6 +26,7 @@ source-repository head
 library
   exposed-modules:
       Frontend.SAST.Abs
+      Frontend.SAST.Convert
       Frontend.Signe.Abs
       Frontend.Signe.ErrM
       Frontend.Signe.Layout
@@ -45,6 +46,7 @@ library
   build-depends:
       array
     , base >=4.7 && <5
+    , containers
   default-language: Haskell2010
 
 executable signe
@@ -60,6 +62,7 @@ executable signe
   build-depends:
       array
     , base >=4.7 && <5
+    , containers
     , signe
   default-language: Haskell2010
 
@@ -77,5 +80,6 @@ test-suite signe-test
   build-depends:
       array
     , base >=4.7 && <5
+    , containers
     , signe
   default-language: Haskell2010

--- a/signe.cabal
+++ b/signe.cabal
@@ -27,6 +27,8 @@ library
   exposed-modules:
       Frontend.SAST.Abs
       Frontend.SAST.Convert
+      Frontend.SAST.Par
+      Frontend.SAST.Print
       Frontend.Signe.Abs
       Frontend.Signe.ErrM
       Frontend.Signe.Layout
@@ -36,6 +38,8 @@ library
       Frontend.Signe.Skel
       Frontend.Signe.Test
       Lib
+      Type.Check
+      Type.Error
   other-modules:
       Paths_signe
   hs-source-dirs:
@@ -47,6 +51,7 @@ library
       array
     , base >=4.7 && <5
     , containers
+    , mtl
   default-language: Haskell2010
 
 executable signe
@@ -63,6 +68,7 @@ executable signe
       array
     , base >=4.7 && <5
     , containers
+    , mtl
     , signe
   default-language: Haskell2010
 
@@ -81,5 +87,6 @@ test-suite signe-test
       array
     , base >=4.7 && <5
     , containers
+    , mtl
     , signe
   default-language: Haskell2010

--- a/signe.cabal
+++ b/signe.cabal
@@ -25,6 +25,7 @@ source-repository head
 
 library
   exposed-modules:
+      Frontend.SAST.Abs
       Frontend.Signe.Abs
       Frontend.Signe.ErrM
       Frontend.Signe.Layout

--- a/src/Frontend/SAST/Abs.hs
+++ b/src/Frontend/SAST/Abs.hs
@@ -7,12 +7,18 @@ type Program = [Toplevel]
 
 data Id 
     = Id
-    { pos  :: (Int, Int)
+    { pos  :: Maybe (Int, Int)
     , name :: String
-    } deriving (Eq, Show, Read, Ord)
+    } deriving Read
 
-data Toplevel = Topl Id [[Id]] (Maybe Type) Expr
-  deriving (Eq, Show, Read)
+instance Eq Id where
+  Id _ a == Id _ b = a == b
+
+instance Ord Id where
+  compare (Id _ a) (Id _ b) = compare a b
+
+data Toplevel = Topl Id [[Id]] (Maybe Scheme) Expr
+  deriving (Eq, Read)
 
 type Let = Map.Map [Id] Expr
 
@@ -29,7 +35,10 @@ data Expr
     | If Expr Expr Expr
     | Let Let Expr
     | Abs [Id] Expr
-  deriving (Eq, Show, Read)
+  deriving (Eq, Read)
 
-data Type = Forall [Id] Type | TypeVar Id | TypeQubit | TypeUnit | Type :* Type | Type :-> Type
-  deriving (Eq, Ord, Show, Read)
+data Scheme = Forall [Id] Type
+  deriving (Eq, Read)
+
+data Type = TypeVar Id | TypeQubit | TypeUnit | Type :* Type | Type :-> Type
+  deriving (Eq, Read)

--- a/src/Frontend/SAST/Abs.hs
+++ b/src/Frontend/SAST/Abs.hs
@@ -1,0 +1,31 @@
+module Frontend.SAST.Abs where
+
+import Data.Complex ( Complex )
+
+type Program = [Toplevel]
+
+data Toplevel
+    = ToplF String [Arg] Expr 
+    | ToplFT String [Arg] Type Expr
+  deriving (Eq, Show, Read)
+
+type Arg = [(String, Type)]
+
+data Expr
+    = Var String
+    | KetZero
+    | KetOne
+    | Tup [Expr]
+    | Mul (Complex Double) Expr
+    | App Expr Expr
+    | Plus Expr Expr
+    | Ifq Expr Expr Expr
+    | If Expr Expr Expr
+    | Let [[(Pattern, Expr)]] Expr
+  deriving (Eq, Show, Read)
+
+data Pattern = PVar String | PTup String String
+  deriving (Eq, Ord, Show, Read)
+
+data Type = TypeQubit | TypeUnit | Type :* Type | Type :-> Type
+  deriving (Eq, Ord, Show, Read)

--- a/src/Frontend/SAST/Abs.hs
+++ b/src/Frontend/SAST/Abs.hs
@@ -1,31 +1,35 @@
 module Frontend.SAST.Abs where
 
 import Data.Complex ( Complex )
+import qualified Data.Map as Map
 
 type Program = [Toplevel]
 
-data Toplevel
-    = ToplF String [Arg] Expr 
-    | ToplFT String [Arg] Type Expr
+data Id 
+    = Id
+    { pos  :: (Int, Int)
+    , name :: String
+    } deriving (Eq, Show, Read, Ord)
+
+data Toplevel = Topl Id [[Id]] (Maybe Type) Expr
   deriving (Eq, Show, Read)
 
-type Arg = [(String, Type)]
+type Let = Map.Map [Id] Expr
 
 data Expr
-    = Var String
+    = Var Id
     | KetZero
     | KetOne
     | Tup [Expr]
     | Mul (Complex Double) Expr
     | App Expr Expr
     | Plus Expr Expr
+    | Comp Expr Expr
     | Ifq Expr Expr Expr
     | If Expr Expr Expr
-    | Let [[(Pattern, Expr)]] Expr
+    | Let Let Expr
+    | Abs [Id] Expr
   deriving (Eq, Show, Read)
 
-data Pattern = PVar String | PTup String String
-  deriving (Eq, Ord, Show, Read)
-
-data Type = TypeQubit | TypeUnit | Type :* Type | Type :-> Type
+data Type = Forall [Id] Type | TypeVar Id | TypeQubit | TypeUnit | Type :* Type | Type :-> Type
   deriving (Eq, Ord, Show, Read)

--- a/src/Frontend/SAST/Convert.hs
+++ b/src/Frontend/SAST/Convert.hs
@@ -1,0 +1,109 @@
+module Frontend.SAST.Convert where
+
+import qualified Frontend.SAST.Abs  as SAST
+import qualified Frontend.Signe.Abs as Signe
+import qualified Data.Map as Map
+import Data.Complex ( Complex(..) )
+import Data.Bifunctor ( Bifunctor(bimap) )
+
+convert :: Signe.Program -> SAST.Program
+convert (Signe.Progr p) = map convertToplevel p
+
+revert :: SAST.Program -> Signe.Program
+revert = Signe.Progr . map revertToplevel
+
+convertToplevel :: Signe.Toplevel -> SAST.Toplevel
+convertToplevel (Signe.ToplF id ps e)    =  SAST.Topl (convertId id) (map convertPattern ps) Nothing (convertExpr e)
+convertToplevel (Signe.ToplFT id ps t e) =  SAST.Topl (convertId id) (map convertPattern ps) (Just (convertType t)) (convertExpr e)
+
+revertToplevel :: SAST.Toplevel -> Signe.Toplevel
+revertToplevel (SAST.Topl id ps Nothing e)  = Signe.ToplF (revertId id) (map revertPattern ps) (revertExpr e)
+revertToplevel (SAST.Topl id ps (Just t) e) = Signe.ToplF (revertId id) (map revertPattern ps) (revertExpr e)
+
+convertExpr :: Signe.Expr -> SAST.Expr
+convertExpr (Signe.EVar id)     = SAST.Var $ convertId id
+convertExpr Signe.ETrue         = SAST.KetOne
+convertExpr Signe.EFalse        = SAST.KetZero
+convertExpr (Signe.ETup es)     = SAST.Tup $ map convertExpr es
+convertExpr (Signe.EMul k e)    = SAST.Mul (convertComplex k) (convertExpr e)
+convertExpr (Signe.EApp e1 e2)  = SAST.App (convertExpr e1) (convertExpr e2)
+convertExpr (Signe.EPlus e1 e2) = SAST.Plus (convertExpr e1) (convertExpr e2)
+convertExpr (Signe.EComp e1 e2) = SAST.Comp (convertExpr e1) (convertExpr e2)
+convertExpr (Signe.EIfq b t f)  = SAST.Ifq (convertExpr b) (convertExpr t) (convertExpr f)
+convertExpr (Signe.EIf b t f)   = SAST.If (convertExpr b) (convertExpr t) (convertExpr f)
+convertExpr (Signe.ELet ls e)   = SAST.Let (foldMap convertLet ls) (convertExpr e)
+convertExpr (Signe.EAbs ids e)  = SAST.Abs (map convertId ids) (convertExpr e)
+
+revertExpr :: SAST.Expr -> Signe.Expr
+revertExpr (SAST.Var id)      = Signe.EVar $ revertId id
+revertExpr SAST.KetOne        = Signe.ETrue
+revertExpr SAST.KetZero       = Signe.EFalse        
+revertExpr (SAST.Tup  es)     = Signe.ETup $ map revertExpr es
+revertExpr (SAST.Mul  k e)    = Signe.EMul (revertComplex k) (revertExpr e)
+revertExpr (SAST.App  e1 e2)  = Signe.EApp (revertExpr e1) (revertExpr e2)
+revertExpr (SAST.Plus  e1 e2) = Signe.EPlus (revertExpr e1) (revertExpr e2)
+revertExpr (SAST.Comp  e1 e2) = Signe.EComp (revertExpr e1) (revertExpr e2)
+revertExpr (SAST.Ifq  b t f)  = Signe.EIfq (revertExpr b) (revertExpr t) (revertExpr f)
+revertExpr (SAST.If  b t f)   = Signe.EIf (revertExpr b) (revertExpr t) (revertExpr f)
+revertExpr (SAST.Let  ls e)   = Signe.ELet (revertLet ls) (revertExpr e)
+revertExpr (SAST.Abs  ids e)  = Signe.EAbs (map revertId ids) (revertExpr e)
+
+convertComplex :: Signe.Complex -> Complex Double
+convertComplex (Signe.CComp re im) = convertScalar re :+ convertScalar im
+convertComplex (Signe.CComn re im) = convertScalar re :+ negate (convertScalar im)
+convertComplex Signe.CPi           = pi
+convertComplex Signe.CE            = exp 1
+convertComplex (Signe.CExp a b)    = convertComplex a ** convertComplex b
+convertComplex (Signe.CDiv a b)    = convertComplex a / convertComplex b
+convertComplex (Signe.CMul a b)    = convertComplex a * convertComplex b
+
+revertComplex :: Complex Double -> Signe.Complex
+revertComplex (a :+ b) = Signe.CComp (revertScalar a) (revertScalar b)
+
+convertScalar :: Signe.Scalar -> Double
+convertScalar (Signe.Scalar s) = read s
+
+revertScalar :: Double -> Signe.Scalar
+revertScalar = Signe.Scalar . show
+
+convertLet :: Signe.Let -> SAST.Let
+convertLet (Signe.LLet p e) = Map.singleton (convertPattern p) (convertExpr e)
+
+revertLet :: SAST.Let -> [Signe.Let]
+revertLet = map (uncurry Signe.LLet . bimap revertPattern revertExpr) . Map.toList
+
+convertId :: Signe.Id -> SAST.Id
+convertId (Signe.Id (pos, name)) = SAST.Id pos name
+
+revertId :: SAST.Id -> Signe.Id
+revertId (SAST.Id pos name) = Signe.Id (pos, name)
+
+convertPattern :: Signe.Pattern -> [SAST.Id]
+convertPattern (Signe.PVar id)  = pure $ convertId id
+convertPattern (Signe.PTup a b) = [convertId a, convertId b]
+
+revertPattern :: [SAST.Id] -> Signe.Pattern
+revertPattern [x]   = Signe.PVar $ revertId x
+revertPattern [x,y] = Signe.PTup (revertId x) (revertId y)
+revertPattern _ = error "You forgot to implement this is the parser. Akward..."
+
+convertType :: Signe.Type -> SAST.Type
+convertType (Signe.TMono t)    = convertMono t
+convertType (Signe.TPoly vs s) = SAST.Forall (map convertId vs) (convertMono s)
+
+revertType :: SAST.Type -> Signe.Type
+revertType (SAST.Forall vs s) = Signe.TPoly (map revertId vs) (revertMono s)
+revertType t                  = Signe.TMono $ revertMono t
+
+convertMono :: Signe.Mono -> SAST.Type
+convertMono (Signe.MVar v)     = SAST.TypeVar $ convertId v
+convertMono Signe.MQubit       = SAST.TypeQubit
+convertMono (Signe.MTens a b)  = convertMono a SAST.:* convertMono b
+convertMono (Signe.MArrow n p) = convertMono n SAST.:-> convertMono p
+
+revertMono :: SAST.Type -> Signe.Mono
+revertMono (SAST.TypeVar v) = Signe.MVar $ revertId v
+revertMono SAST.TypeQubit   = Signe.MQubit
+revertMono (a SAST.:* b)    = Signe.MTens (revertMono a) (revertMono b)
+revertMono (a SAST.:-> b)   = Signe.MArrow (revertMono a) (revertMono b)
+revertMono _ = error "You forgot to implement this is the parser. Akward..."

--- a/src/Frontend/SAST/Par.hs
+++ b/src/Frontend/SAST/Par.hs
@@ -1,0 +1,24 @@
+module Frontend.SAST.Par where
+
+import Frontend.Signe.Par
+import Frontend.Signe.Lex ( Token )
+import Frontend.Signe.Layout
+import Frontend.SAST.Abs
+import Frontend.SAST.Convert
+
+ofParser :: (t -> p) -> ([Token] -> Either String t) -> String -> p
+ofParser conv par s = case par (resolveLayout False (myLexer s)) of
+    Right e -> conv e
+    Left  s -> error s
+
+parseExpr :: String -> Expr
+parseExpr = convertExpr `ofParser` pExpr
+
+parseType :: String -> Scheme
+parseType = convertType `ofParser` pType
+
+parseToplevel :: String -> Toplevel
+parseToplevel = convertToplevel `ofParser` pToplevel
+
+parse :: String -> Program
+parse = convert `ofParser` pProgram

--- a/src/Frontend/SAST/Print.hs
+++ b/src/Frontend/SAST/Print.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Frontend.SAST.Print where
+
+import Frontend.SAST.Abs
+    ( Type, Expr, Toplevel, Id(Id, name), Scheme )
+import Frontend.SAST.Convert
+    ( revertToplevel, revertType, revertExpr, revertMono )
+import Frontend.Signe.Print ( printTree )
+
+instance Show Id where
+    show Id{name} = name
+
+instance Show Toplevel where
+    show = printTree . revertToplevel
+
+instance Show Expr where
+    show = printTree . revertExpr
+
+instance Show Scheme where
+    show = printTree . revertType
+
+instance Show Type where
+    show = printTree . revertMono

--- a/src/Type/Check.hs
+++ b/src/Type/Check.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE CPP, MagicHash             #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE LambdaCase                 #-}
+
+module Type.Check where
+
+#define DEBUG
+
+import Frontend.SAST.Abs
+import Type.Error
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Data.Functor
+import Data.Bifunctor
+import Data.Complex
+import Data.List
+import Control.Monad.Except
+import Control.Monad.State
+
+#ifdef DEBUG
+
+import Frontend.SAST.Par ( parseExpr )
+import Debug.Trace ( trace )
+
+checkExpr :: Expr -> Either TypeError Scheme
+checkExpr = runCheck . infer emptyContext
+
+inferExpr :: String -> Scheme
+inferExpr = either (error . show) id . checkExpr . parseExpr
+
+debug :: Monad m => String -> m ()
+debug = flip trace (return ()) 
+
+#endif
+
+newtype Context = Context (Map.Map Id Scheme)
+    deriving (Eq, Show)
+
+emptyContext :: Context
+emptyContext = Context Map.empty
+
+lookupContext :: Context -> Id -> Check (Subst, Type)
+lookupContext (Context c) x =
+  case Map.lookup x c of
+    Nothing -> throwError $ VariableNotInScope x
+    Just s  -> do t <- instantiate s
+                  return (nullSubst, t)
+
+extend :: Context -> ([Id], Scheme) -> Context
+extend (Context c) = Context . go
+    where go :: ([Id], Scheme) -> Map.Map Id Scheme
+          go ([x],s) = Map.insert x s c
+          go (x:xs, Forall vs (a :* b)) =
+              Map.insert x (Forall vs a) $ go (xs, Forall vs b)
+          go _ = urk
+
+type Fresh = Int
+
+newtype Check a = Check (ExceptT TypeError (State Fresh) a)
+    deriving (Functor, Applicative, Monad, MonadState Fresh, MonadError TypeError)
+
+runCheck :: Check (Subst, Type) -> Either TypeError Scheme
+runCheck (Check m) = case evalState (runExceptT m) 0 of
+    Left  e -> Left e
+    Right s -> Right $ closeOver s
+
+closeOver :: (Map.Map Id Type, Type) -> Scheme
+closeOver (sub, ty) = normalize sc
+  where sc = generalize emptyContext (apply sub ty)
+
+normalize :: Scheme -> Scheme
+normalize (Forall ts body) = Forall (fmap snd ord) (normtype body)
+  where
+    ord = zip (nub $ fv body) letters
+
+    fv (TypeVar a) = [a]
+    fv (n :-> p)   = fv n <> fv p
+    fv (a :* b)    = fv a <> fv b
+    fv _           = []
+
+    normtype (a :-> b)   = normtype a :-> normtype b
+    normtype (a :* b)    = normtype a :* normtype b
+    normtype TypeQubit   = TypeQubit
+    normtype TypeUnit    = TypeUnit
+    normtype (TypeVar a) = maybe urk TypeVar (lookup a ord)
+
+type Subst = Map.Map Id Type
+
+nullSubst :: Subst
+nullSubst = Map.empty
+
+compose, (∘) :: Subst -> Subst -> Subst
+compose s1 s2 = Map.map (apply s1) s2 `Map.union` s1
+(∘) = compose
+
+class Substitutable a where
+    apply :: Subst -> a -> a
+    ftv   :: a -> Set.Set Id
+
+instance Substitutable Type where
+    apply _ TypeQubit  = TypeQubit
+    apply _ TypeUnit   = TypeUnit
+    apply s t@(TypeVar id) = Map.findWithDefault t id s
+    apply s (n :-> p)  = apply s n :-> apply s p
+    apply s (a :* b)   = apply s a :* apply s b
+
+    ftv TypeQubit   = Set.empty
+    ftv TypeUnit    = Set.empty
+    ftv (TypeVar a) = Set.singleton a
+    ftv (n :-> p)   = ftv n `Set.union` ftv p
+    ftv (a :* b)    = ftv a `Set.union` ftv b
+
+instance Substitutable Scheme where
+    apply s (Forall vs t) = Forall vs $ apply (foldr Map.delete s vs) t
+    ftv (Forall vs t) = ftv t `Set.difference` Set.fromList vs
+
+instance Substitutable a => Substitutable [a] where
+    apply = fmap . apply
+    ftv = foldr (Set.union . ftv) Set.empty
+
+instance Substitutable Context where
+    apply s (Context c) = Context $ Map.map (apply s) c
+    ftv (Context c) = ftv $ Map.elems c
+
+letters :: [Id]
+letters = [1..] >>= fmap (Id Nothing) . flip replicateM ['a'..'z']
+
+fresh :: Check Type
+fresh = modify (+1) >> gets (TypeVar . (letters !!))
+
+occursCheck :: Substitutable a => Id -> a -> Bool
+occursCheck a t = a `Set.member` ftv t
+
+unify :: Type -> Type -> Check Subst
+unify (l :-> r) (l' :-> r') = do
+    s1 <- unify l l'
+    s2 <- unify (apply s1 r) (apply s1 r')
+    return $ s2 ∘ s1
+unify (l :* r) (l' :* r') = compose <$> unify l l' <*> unify r r'
+unify (TypeVar v) t = bind v t
+unify t (TypeVar v) = bind v t
+unify s t
+    | s == t    = return nullSubst
+    | otherwise = throwError $ TypeMismatch s t
+
+bind :: Id -> Type -> Check Subst
+bind v t
+    | t == TypeVar v  = return nullSubst
+    | occursCheck v t = throwError $ InfiniteType v t
+    | otherwise       = return $ Map.singleton v t
+
+instantiate :: Scheme -> Check Type
+instantiate (Forall vs t) = do
+    vs' <- mapM (const fresh) vs
+    let s = Map.fromList $ zip vs vs'
+    return $ apply s t
+
+generalize :: Context -> Type -> Scheme
+generalize c t = Forall vs t
+    where vs = Set.toList $ ftv t `Set.difference` ftv c
+
+infer :: Context -> Expr -> Check (Subst, Type)
+infer c = \case
+    Var x -> lookupContext c x
+
+    KetZero -> return (nullSubst, TypeQubit)
+
+    KetOne -> return (nullSubst, TypeQubit)
+
+    Tup [] -> return (nullSubst, TypeUnit)
+
+    Tup xs -> foldM
+        (\(s,t) e -> infer c e <&> bimap (s∘) (t:*))
+        (nullSubst, TypeUnit)
+        xs
+
+    m@(Mul k e) -> do
+        unless (magnitude k == 1) $ throwError $ ScalarNotNormalized m
+        (se, te) <- infer c e
+        sr <- unify te TypeQubit
+        return (sr ∘ se, apply sr te)
+
+    App a b -> do
+        tv <- fresh
+        (sa, ta) <- infer c a
+        (sb, tb) <- infer (apply sa c) b
+        sr       <- unify (apply sb ta) (tb :-> tv)
+        return (sr ∘ sb ∘ sa, apply sr tv)
+
+    Plus a b -> do
+        (sa, ta) <- infer c a
+        (sb, tb) <- infer c b
+        sa'      <- unify (apply sb ta) TypeQubit
+        sb'      <- unify (apply sa' tb) TypeQubit
+        return (sb' ∘ sa' ∘ sb ∘ sa, apply sb' tb)
+
+    Comp f g -> do
+        tf       <- fresh
+        tfg      <- fresh
+        tg       <- fresh
+        (sf, tf) <- infer c f
+        (sg, tg) <- infer (apply sf c) g
+        sz       <- unify (apply sg tf) (tf :-> tfg)
+        szz      <- unify (apply sz tg) (tfg :-> tg)
+
+        return (szz ∘ sz ∘ sg ∘ sf, apply szz (tf :-> tg))
+
+    Ifq b t f -> do
+        (s1,t1) <- infer c b
+        (s2,t2) <- infer c t
+        (s3,t3) <- infer c f
+        s4 <- unify TypeQubit t1
+        s5 <- unify t2 t3
+        return (s5 ∘ s4 ∘ s3 ∘ s2 ∘ s1, apply s5 t2)
+
+    If b t f -> do
+        (s1,t1) <- infer c b
+        (s2,t2) <- infer c t
+        (s3,t3) <- infer c f
+        s4 <- unify TypeQubit t1
+        s5 <- unify t2 t3
+        return (s5 ∘ s4 ∘ s3 ∘ s2 ∘ s1, apply s5 t2)
+
+    Let ps e -> do
+        is <- mapM (infer c) ps
+        let (ss, ts) = unzip $ Map.elems is
+            vs       = Map.keys is
+            c'       = apply (foldl1 (∘) ss) c
+            ts'      = map (generalize c') ts
+            c''      = foldl extend c' $ zip vs ts'
+
+        (se, te) <- infer c'' e
+
+        return (foldl (∘) se ss, te)
+
+    Abs [x] e -> do
+        tv <- fresh
+        let env' = c `extend` ([x], Forall [] tv)
+        (s1, t1) <- infer env' e
+        return (s1, apply s1 tv :-> t1)
+
+    Abs x e -> do
+        tv <- fresh
+        c' <- foldl extend c <$> mapM (\v -> ([v],) . Forall [] <$> fresh) x
+        (s1, t1) <- infer c' e
+        return (s1, apply s1 tv :-> t1)

--- a/src/Type/Error.hs
+++ b/src/Type/Error.hs
@@ -1,0 +1,14 @@
+module Type.Error where
+
+import Frontend.SAST.Abs
+import Frontend.SAST.Print ()
+
+data TypeError
+    = TypeMismatch Type Type
+    | InfiniteType Id Type
+    | VariableNotInScope Id
+    | ScalarNotNormalized Expr
+    deriving Show
+
+urk :: a
+urk = error "urk"


### PR DESCRIPTION
Adds the first version of the Hindley-Milner type checker. Note that no orthogonality constraints are imposed as of yet.

Some issues remain here, namely.
* The checker urks on `let (a,b) = ~0 in a`. This needs to be caught before the urk even happens.
* The case of tuples is incorrect since the base case is of the unit type. That is product types are extended like so: `(~0,~1) : unit * qubit * qubit`. This is probably the cause of the first issue.